### PR TITLE
refactor: switch to async jobs

### DIFF
--- a/plugin/zoxide.vim
+++ b/plugin/zoxide.vim
@@ -26,20 +26,20 @@ execute 'command! -nargs=* -bang T' .. s:z_cmd .. 'i call zoxide#zi("tcd", <bang
 if get(g:, 'zoxide_legacy_aliases', 0)
     " Za
     " Zr
-    execute 'command! -nargs=? -complete=dir ' .. s:z_cmd_cap .. 'a call zoxide#exec(["add"], [<q-args>])'
-    execute 'command! -nargs=? -complete=dir ' .. s:z_cmd_cap .. 'r call zoxide#exec(["remove"], [<q-args>])'
+    execute 'command! -nargs=? -complete=dir ' .. s:z_cmd_cap .. 'a call zoxide#exec(["add", <q-args>])'
+    execute 'command! -nargs=? -complete=dir ' .. s:z_cmd_cap .. 'r call zoxide#exec(["remove", <q-args>])'
 endif
 
 if get(g:, 'zoxide_hook', 'none') ==# 'pwd'
     if has('nvim')
         augroup zoxide_cd
             autocmd!
-            autocmd DirChanged * if !v:event['changed_window'] | call zoxide#exec(['add'], [v:event['cwd']]) | endif
+            autocmd DirChanged * if !v:event['changed_window'] | call zoxide#exec(['add', v:event['cwd']]) | endif
         augroup END
     else
         augroup zoxide_cd
             autocmd!
-            autocmd DirChanged window,tabpage,global call zoxide#exec(['add'], [expand('<afile>')])
+            autocmd DirChanged window,tabpage,global call zoxide#exec(['add', expand('<afile>')])
         augroup END
     endif
 endif


### PR DESCRIPTION
This is an experiment to see if async jobs are a viable option for this plugin

Advantages of jobs:

- They don't block the editor so the overall experience is smoother
- No escaping necessary, I can just pass the arguments as a List. No shells involved, no problems :sunglasses:
- Some shells are slow to start. Since this bypasses the shell, command invocations should be faster

Disadvantages of jobs:

- Jobs rely on callbacks, which makes the code considerably more convoluted (I can probably clean this up some more...).
- I have to handle the differences between Vim and Neovim :cry: