### PR TITLE
docs: add more tags to vimdocs and seperators before sections

### DIFF
--- a/doc/zoxide-vim.txt
+++ b/doc/zoxide-vim.txt
@@ -1,24 +1,26 @@
 *zoxide-vim.txt*	A small (Neo)Vim wrapper for zoxide
 
-USAGE					*zoxide-vim* *:Z*
+USAGE					*zoxide-vim* *zoxide-vim-usage*
 
-:Z {query}		cd to the highest ranked directory matching your
-			query. If {query} is omitted, cd to the home
-			directory.
+							*:Z*
+:Z {query}		cd to the highest ranked directory matching your query.
+			If {query} is omitted, cd to the home directory.
 
-:Lz {query}		same as :Z but local to the current
-			window.
+							*:Lz*
+:Lz {query}		same as :Z but local to the current window.
 
+							*:Tz*
 :Tz {query}		same as :Z but local to the current tab.
 
+							*:Zi*
 :Zi {query}		cd to one of your highest ranking directories using
 			fzf.
 
-:Lzi {query}		same as :Zi, but local to the current
-			window.
+							*:Lzi*
+:Lzi {query}		same as :Zi, but local to the current window.
 
-:Tzi {query}		same as :Zi, but local to the current
-			tab.
+							*:Tzi*
+:Tzi {query}		same as :Zi, but local to the current tab.
 
 CONFIGURATION				*zoxide-vim-configuration*
 
@@ -67,8 +69,8 @@ g:zoxide_hook
 
 					*g:zoxide_use_select*
 g:zoxide_use_select
-			Use |vim.ui.select()| for :Zi-style commands
-			(Neovim `0.6.0+` only)
+			Use |vim.ui.select()| for :Zi-style commands (Neovim
+			`0.6.0+` only)
 
 			Default value: `0`
 

--- a/doc/zoxide-vim.txt
+++ b/doc/zoxide-vim.txt
@@ -1,5 +1,6 @@
 *zoxide-vim.txt*	A small (Neo)Vim wrapper for zoxide
 
+===============================================================================
 USAGE					*zoxide-vim* *zoxide-vim-usage*
 
 							*:Z*
@@ -22,6 +23,7 @@ USAGE					*zoxide-vim* *zoxide-vim-usage*
 							*:Tzi*
 :Tzi {query}		same as :Zi, but local to the current tab.
 
+===============================================================================
 CONFIGURATION				*zoxide-vim-configuration*
 
 					*g:zoxide_executable*


### PR DESCRIPTION
Hey there,

I noticed I couldn't find help on the `:Lz`/`:Tz` commands, so I thought I'd open a PR to add tags for those commands. While I was in there I re-wrapped a few lines to the text width and added a `*zoxide-vim-usage*` tag. 

I thought the readability of the file was helped a bit if there were separators between the sections, as documented in `:help help-writing`, so I added that in a separate commit too. 

Hope this is helpful!