### PR TITLE
Add option to automatically open the directory explorer

### DIFF
--- a/autoload/zoxide.vim
+++ b/autoload/zoxide.vim
@@ -18,6 +18,14 @@ function! s:change_directory(cd_command, directory) abort
         return
     endtry
 
+    if get(g:, 'zoxide_opendir', 0)
+      let is_dir_buffer = bufname() =~ '^/.*/$'
+      let is_empty_buffer = empty(bufname()) && getline(1, '$') == ['']
+      if is_dir_buffer || is_empty_buffer
+        edit .
+      endif
+    endif
+
     pwd
 
     if get(g:, 'zoxide_update_score', 1) && get(g:, 'zoxide_hook', 'none') !=# 'pwd'

--- a/doc/zoxide-vim.txt
+++ b/doc/zoxide-vim.txt
@@ -88,4 +88,12 @@ g:zoxide_fzf_options
 <
 			Accepts a string or an array of strings.
 
+					*g:zoxide_opendir*
+g:zoxide_opendir
+			When set to `1`, automatically opens the directory
+			explorer after changing directories if there isn't an
+			opened buffer already.
+
+			Default value: `0`
+
 vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
Most of the time after I `:Z` into a directory I immediately run `:e .` to get my bearings. It would make my navigation more efficient if this could be done automatically. On the other hand, some of the time I already have a file open and I want to change directories for other purposes (to run commands from a different dir, for example) but not necessarily leave the file I am working on. What I want is context sensitive behavior, so that I get the automatic `:e .` behavior when it's almost certainly unobtrusive, while doing no such `:e .` behavior when there is any chance it could mess with buffers I am working on.

I'm putting up this PR as a feeler to see if there is any interest in incorporating support for something like this in zoxide.vim. **Full disclaimer**: I have not tried out these changes for an extended period of time. My plan is to try it out for a while and then report back if there are issues or if I consider it good to go.

An alternative approach to supporting this functionality—instead of the option added by this PR—would be to offer a hook after changing directories so that users could register arbitrary commands to run.